### PR TITLE
Upgrade dependencies and qulice 0.27.5; align JUnit 6 + Java 17/21 matrix

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.68.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>org.eolang</groupId>
   <artifactId>jucs</artifactId>
@@ -66,18 +66,16 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.57.0</version>
+      <version>0.61.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.10.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -89,11 +87,27 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.24.0</version>
+            <version>0.27.5</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <configuration>
+              <excludes combine.children="append">
+                <exclude>**/errorprone-classes/**</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/src/main/java/org/eolang/jucs/ClasspathSource.java
+++ b/src/main/java/org/eolang/jucs/ClasspathSource.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 /**
  * The annotation for your JUnit5 test methods.
- *
  * @since 0.0.1
  */
 @Documented
@@ -34,5 +33,4 @@ public @interface ClasspathSource {
      * @return Glob searching pattern, e.g. "**&#47;*.txt"
      */
     String glob() default "**/*.txt";
-
 }

--- a/src/main/java/org/eolang/jucs/JucsProvider.java
+++ b/src/main/java/org/eolang/jucs/JucsProvider.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 /**
  * Provider of the sources.
- *
  * @since 0.0.1
  */
 final class JucsProvider implements ArgumentsProvider,
@@ -33,6 +33,11 @@ final class JucsProvider implements ArgumentsProvider,
      * Is it a file?
      */
     private static final Pattern IS_FILE = Pattern.compile("^.+\\.[a-z]+$");
+
+    /**
+     * Line separator used to split classpath listings.
+     */
+    private static final Pattern NEWLINE = Pattern.compile("\\R");
 
     /**
      * The annotation of the user.
@@ -46,7 +51,7 @@ final class JucsProvider implements ArgumentsProvider,
 
     @Override
     public Stream<? extends Arguments> provideArguments(
-        final ExtensionContext ctx) {
+        final ParameterDeclarations params, final ExtensionContext ctx) {
         return this.yamls("").stream();
     }
 
@@ -58,13 +63,12 @@ final class JucsProvider implements ArgumentsProvider,
     private Collection<Arguments> yamls(final String prefix) {
         final Collection<Arguments> out = new LinkedList<>();
         final String home = String.format("%s/%s", this.sanitized(), prefix);
-        final String folder = new UncheckedText(
-            new TextOf(new ResourceOf(home))
-        ).asString();
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(
             String.format("glob:%s", this.annotation.glob())
         );
-        final String[] subs = folder.split("\n");
+        final String[] subs = JucsProvider.NEWLINE.split(
+            new UncheckedText(new TextOf(new ResourceOf(home))).asString()
+        );
         for (final String sub : subs) {
             final Path path = Paths.get(String.format("%s%s", prefix, sub));
             if (matcher.matches(path)) {

--- a/src/main/java/org/eolang/jucs/package-info.java
+++ b/src/main/java/org/eolang/jucs/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * JUnit Classpath Sources.
- *
  * @since 0.0.1
  */
 package org.eolang.jucs;

--- a/src/test/java/org/eolang/jucs/JucsProviderTest.java
+++ b/src/test/java/org/eolang/jucs/JucsProviderTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Simple test case.
- *
  * @since 0.0.1
+ * @checkstyle ProhibitLineSeparatorInStringsCheck (50 lines)
  */
 final class JucsProviderTest {
 
@@ -37,5 +37,4 @@ final class JucsProviderTest {
     void findsWithLocalGlob(final String file) {
         Assertions.assertEquals(file, "hey!\n");
     }
-
 }

--- a/src/test/java/org/eolang/jucs/package-info.java
+++ b/src/test/java/org/eolang/jucs/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * JUnit Classpath Sources.
- *
  * @since 0.0.1
  */
 package org.eolang.jucs;


### PR DESCRIPTION
@yegor256 — this PR brings every direct dependency, plugin, and the qulice linter up to its latest stable version, then resolves every lint issue (new and pre-existing) so the build is green again on every supported OS. Ready for merge.

## Dependency bumps

| Artifact | From | To |
|---|---|---|
| `com.jcabi:parent` | 0.68.0 | 0.73.1 |
| `org.cactoos:cactoos` | 0.57.0 | 0.61.0 |
| `org.junit.jupiter:junit-jupiter-api` | 5.10.1 | 6.0.3 (managed by parent BOM) |
| `org.junit.jupiter:junit-jupiter-params` | 5.10.1 | 6.0.3 (managed by parent BOM) |
| `com.qulice:qulice-maven-plugin` | 0.24.0 | 0.27.5 |

The new `parent` 0.73.1 imports `org.junit:junit-bom` 6.0.3, so I dropped the explicit JUnit versions from `pom.xml` and let the BOM manage them — keeping a single source of truth and avoiding the version mix that broke the build on the first attempt (`5.12.x` API + `6.0.3` engine pulled by the parent's `jcabi-junit` profile).

## CI matrix change

The previous mvn matrix included Java 11 and 17. qulice 0.27.5 is now compiled against Java 21 (class file version 65 — verified locally on Temurin 17 with `UnsupportedClassVersionError` on `com/qulice/maven/CheckMojo`), so the matrix is now `java: [21]`, matching the convention used after the same bump in `jcabi-jdbc`, `jcabi-log`, and `jcabi-urn`.

## Code-level adjustments required by these bumps

- **JUnit 6 deprecates the old `ArgumentsProvider#provideArguments(ExtensionContext)`.** `JucsProvider` now implements the new signature `provideArguments(ParameterDeclarations, ExtensionContext)`, which is the future-proof one and removes the `-Werror` deprecation that compilation otherwise hits.
- **qulice 0.27.5 enables several new checkstyle/PMD rules.** Resolved every new violation across `main` and `test` rather than suppressing the rules globally:
  - `JavadocEmptyLineBeforeTagCheck` — removed empty `*` lines before single-paragraph javadoc `@`-tags in `JucsProvider`, `ClasspathSource`, `JucsProviderTest`, and both `package-info.java` files.
  - `RegexpMultilineCheck` ("empty line before closing brace") — stripped those blank lines from `ClasspathSource` and `JucsProviderTest`.
  - `SimpleStringSplitCheck` — precompiled the line-separator regex into a `static final Pattern NEWLINE` field (also future-proofs the call to handle `\r\n`).
  - `PMD.UnnecessaryLocalRule` — inlined the `folder` local that fell out after the split refactor.
  - `ProhibitLineSeparatorInStringsCheck` — the `"hey!\n"` literals in `JucsProviderTest` match the LF stored in the test resources (enforced by `.gitattributes` `* text=auto eol=lf`), not a platform separator. The class therefore carries the standard `// @checkstyle ProhibitLineSeparatorInStringsCheck` suppression rather than getting rewritten with `%n` (which would flip behaviour on Windows).

## Pre-existing fix

The `codecov` workflow (`mvn install -Pjacoco`) was already failing on master with `Can't add different class with same name: org/eolang/jucs/ClasspathSource` because the parent's compilation step copies classes into `target/classes/errorprone-classes/` next to the originals, and jacoco then sees both. Added a project-level override of the `jacoco` profile that excludes `**/errorprone-classes/**` from the report — both `mvn install -Pqulice` and `mvn install -Pjacoco` are now green.

## CI status

All 11 checks green on the current head (`32b0f1d`):

- mvn (ubuntu-24.04, 21), mvn (windows-2022, 21), mvn (macos-15, 21)
- actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint

Ready for review/merge.