### PR TITLE
feat(#84): expose classpath path as optional second test parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.iml
 node_modules/
 target/
+.aidy/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 node_modules/
 target/
 .aidy/
+.claude/

--- a/src/main/java/org/eolang/jucs/JucsProvider.java
+++ b/src/main/java/org/eolang/jucs/JucsProvider.java
@@ -52,15 +52,16 @@ final class JucsProvider implements ArgumentsProvider,
     @Override
     public Stream<? extends Arguments> provideArguments(
         final ParameterDeclarations params, final ExtensionContext ctx) {
-        return this.yamls("").stream();
+        return this.yamls("", params.getAll().size() > 1).stream();
     }
 
     /**
      * Find all YAMLs recursively on classpath.
      * @param prefix Prefix (empty when it starts)
+     * @param withpath Whether to include the classpath path as a second argument
      * @return The list of full paths
      */
-    private Collection<Arguments> yamls(final String prefix) {
+    private Collection<Arguments> yamls(final String prefix, final boolean withpath) {
         final Collection<Arguments> out = new LinkedList<>();
         final String home = String.format("%s/%s", this.sanitized(), prefix);
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(
@@ -72,22 +73,18 @@ final class JucsProvider implements ArgumentsProvider,
         for (final String sub : subs) {
             final Path path = Paths.get(String.format("%s%s", prefix, sub));
             if (matcher.matches(path)) {
-                out.add(
-                    Arguments.of(
-                        Named.of(
-                            path.toString(),
-                            new UncheckedText(
-                                new TextOf(
-                                    new ResourceOf(
-                                        String.format("%s%s", home, sub)
-                                    )
-                                )
-                            ).asString()
-                        )
-                    )
-                );
+                final String content = new UncheckedText(
+                    new TextOf(new ResourceOf(String.format("%s%s", home, sub)))
+                ).asString();
+                if (withpath) {
+                    out.add(
+                        Arguments.of(Named.of(path.toString(), content), path.toString())
+                    );
+                } else {
+                    out.add(Arguments.of(Named.of(path.toString(), content)));
+                }
             } else if (!JucsProvider.IS_FILE.matcher(sub).matches()) {
-                out.addAll(this.yamls(String.format("%s/", sub)));
+                out.addAll(this.yamls(String.format("%s/", sub), withpath));
             }
         }
         return out;

--- a/src/main/java/org/eolang/jucs/JucsProvider.java
+++ b/src/main/java/org/eolang/jucs/JucsProvider.java
@@ -76,18 +76,28 @@ final class JucsProvider implements ArgumentsProvider,
                 final String content = new UncheckedText(
                     new TextOf(new ResourceOf(String.format("%s%s", home, sub)))
                 ).asString();
+                final String normalized = JucsProvider.normalize(path);
                 if (withpath) {
                     out.add(
-                        Arguments.of(Named.of(path.toString(), content), path.toString())
+                        Arguments.of(Named.of(normalized, content), normalized)
                     );
                 } else {
-                    out.add(Arguments.of(Named.of(path.toString(), content)));
+                    out.add(Arguments.of(Named.of(normalized, content)));
                 }
             } else if (!JucsProvider.IS_FILE.matcher(sub).matches()) {
                 out.addAll(this.yamls(String.format("%s/", sub), withpath));
             }
         }
         return out;
+    }
+
+    /**
+     * Normalize path to use forward slashes on all platforms.
+     * @param path The path to normalize
+     * @return The normalized path string
+     */
+    private static String normalize(final Path path) {
+        return path.toString().replace('\\', '/');
     }
 
     /**

--- a/src/test/java/org/eolang/jucs/JucsProviderTest.java
+++ b/src/test/java/org/eolang/jucs/JucsProviderTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.jucs;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 
@@ -50,5 +51,12 @@ final class JucsProviderTest {
     void exposesNestedPath(final String content, final String path) {
         Assertions.assertFalse(content.isEmpty());
         Assertions.assertEquals("foo/a.txt", path);
+    }
+
+    @ParameterizedTest
+    @ClasspathSource(value = "com/yegor256/jucs", glob = "**/*.text")
+    void exposesPathForTextFiles(final String content, final String path) {
+        Assertions.assertFalse(content.isEmpty());
+        Assertions.assertTrue(List.of("x.text", "bar/y.text").contains(path));
     }
 }

--- a/src/test/java/org/eolang/jucs/JucsProviderTest.java
+++ b/src/test/java/org/eolang/jucs/JucsProviderTest.java
@@ -37,4 +37,18 @@ final class JucsProviderTest {
     void findsWithLocalGlob(final String file) {
         Assertions.assertEquals(file, "hey!\n");
     }
+
+    @ParameterizedTest
+    @ClasspathSource(value = "com/yegor256/jucs/foo", glob = "*.txt")
+    void exposesLocalPath(final String content, final String path) {
+        Assertions.assertFalse(content.isEmpty());
+        Assertions.assertEquals("a.txt", path);
+    }
+
+    @ParameterizedTest
+    @ClasspathSource(value = "com/yegor256/jucs", glob = "**/*.txt")
+    void exposesNestedPath(final String content, final String path) {
+        Assertions.assertFalse(content.isEmpty());
+        Assertions.assertEquals("foo/a.txt", path);
+    }
 }

--- a/src/test/java/org/eolang/jucs/JucsProviderTest.java
+++ b/src/test/java/org/eolang/jucs/JucsProviderTest.java
@@ -4,7 +4,7 @@
  */
 package org.eolang.jucs;
 
-import java.util.List;
+import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 
@@ -54,6 +54,6 @@ final class JucsProviderTest {
     @ParameterizedTest
     @ClasspathSource(value = "com/yegor256/jucs", glob = "**/*.text")
     void exposesPathForTextFiles(final String content, final String path) {
-        Assertions.assertTrue(List.of("x.text", "bar/y.text").contains(path));
+        Assertions.assertTrue(Arrays.asList("x.text", "bar/y.text").contains(path));
     }
 }

--- a/src/test/java/org/eolang/jucs/JucsProviderTest.java
+++ b/src/test/java/org/eolang/jucs/JucsProviderTest.java
@@ -42,21 +42,18 @@ final class JucsProviderTest {
     @ParameterizedTest
     @ClasspathSource(value = "com/yegor256/jucs/foo", glob = "*.txt")
     void exposesLocalPath(final String content, final String path) {
-        Assertions.assertFalse(content.isEmpty());
         Assertions.assertEquals("a.txt", path);
     }
 
     @ParameterizedTest
     @ClasspathSource(value = "com/yegor256/jucs", glob = "**/*.txt")
     void exposesNestedPath(final String content, final String path) {
-        Assertions.assertFalse(content.isEmpty());
         Assertions.assertEquals("foo/a.txt", path);
     }
 
     @ParameterizedTest
     @ClasspathSource(value = "com/yegor256/jucs", glob = "**/*.text")
     void exposesPathForTextFiles(final String content, final String path) {
-        Assertions.assertFalse(content.isEmpty());
         Assertions.assertTrue(List.of("x.text", "bar/y.text").contains(path));
     }
 }


### PR DESCRIPTION
Expose the classpath path as an optional second parameter in `@ClasspathSource` parameterized tests, allowing test methods to access the fixture path alongside its content.

Fixes #84